### PR TITLE
Move all pages into index.page.tsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,10 +28,6 @@
     "no-restricted-imports": ["error", {
       "patterns": [
         {
-          "group": ["../*"],
-          "message": "Relative path imports are prohibited. Please use absolute path from project root instead."
-        },
-        {
           "group": ["generated/types/*"],
           "message": "Direct imports from `generated/types/*` are prohibited. Please use `generated/types` instead."
         }

--- a/pages/vaults/[id]/index.page.tsx
+++ b/pages/vaults/[id]/index.page.tsx
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { useRouter } from 'next/router';
 
-import VaultManipulator from './VaultManager';
+import VaultManipulator from '../VaultManager';
 
 import type { NextPageWithEthereum } from 'next';
 

--- a/pages/vaults/open/index.page.tsx
+++ b/pages/vaults/open/index.page.tsx
@@ -1,4 +1,4 @@
-import VaultManipulator from './VaultManager';
+import VaultManipulator from '../VaultManager';
 
 import type { NextPageWithEthereum } from 'next';
 


### PR DESCRIPTION
今後 `app/` にページを移動するにあたり、 `index.page.tsx` のみを使用するようにします。
現在これを強制する機械的なチェックを検討中ですが、いまのところ良策が見つかっていないので手動での確認とします。