### PR TITLE
Use FixedNumber instead of BigNumber for CDP ID

### DIFF
--- a/contracts/CDPManagerHelper.ts
+++ b/contracts/CDPManagerHelper.ts
@@ -1,10 +1,11 @@
 import { DSProxy__factory, DssCdpManager__factory } from 'generated/types';
 
 import IlkType from './IlkType';
+import { INT_FORMAT, toBigNumber } from './math';
 
 import type EthereumProvider from './EthereumProvider';
 import type { CDP } from './GetCDPsHelper';
-import type { BigNumber } from 'ethers';
+import type { FixedNumber } from 'ethers';
 import type { DssCdpManager } from 'generated/types';
 
 export default class CDPManagerHelper {
@@ -20,19 +21,21 @@ export default class CDPManagerHelper {
     return this.contract.address;
   }
 
-  private getIlkType(cdpId: BigNumber) {
-    return this.contract.ilks(cdpId).then((typeBytes32) => IlkType.fromBytes32(typeBytes32));
+  private getIlkType(cdpId: FixedNumber) {
+    return this.contract.ilks(toBigNumber(cdpId, INT_FORMAT)).then((typeBytes32) => IlkType.fromBytes32(typeBytes32));
   }
 
-  private getUrn(cdpId: BigNumber) {
-    return this.contract.urns(cdpId);
+  private getUrn(cdpId: FixedNumber) {
+    return this.contract.urns(toBigNumber(cdpId, INT_FORMAT));
   }
 
-  private getOwner(cdpId: BigNumber) {
-    return this.contract.owns(cdpId).then((address) => DSProxy__factory.connect(address, this.provider.getSigner()));
+  private getOwner(cdpId: FixedNumber) {
+    return this.contract
+      .owns(toBigNumber(cdpId, INT_FORMAT))
+      .then((address) => DSProxy__factory.connect(address, this.provider.getSigner()));
   }
 
-  getCDP(cdpId: BigNumber): Promise<CDP> {
+  getCDP(cdpId: FixedNumber): Promise<CDP> {
     return Promise.all([this.getUrn(cdpId), this.getIlkType(cdpId), this.getOwner(cdpId)]).then(([urn, ilk, owner]) => ({
       id: cdpId,
       urn,

--- a/contracts/GetCDPsHelper.ts
+++ b/contracts/GetCDPsHelper.ts
@@ -1,13 +1,15 @@
 import IlkType from 'contracts/IlkType';
 import { GetCdps__factory } from 'generated/types';
 
+import { INT_FORMAT, toFixedNumber } from './math';
+
 import type CDPManagerHelper from './CDPManagerHelper';
 import type EthereumProvider from './EthereumProvider';
-import type { BigNumber } from 'ethers';
+import type { FixedNumber } from 'ethers';
 import type { GetCdps, DSProxy } from 'generated/types';
 
 export type CDP = {
-  id: BigNumber;
+  id: FixedNumber;
   urn: string;
   ilk: IlkType;
   owner: DSProxy;
@@ -25,7 +27,7 @@ export default class GetCDPsHelper {
   getCDPs(proxy: DSProxy): Promise<CDP[]> {
     return this.contract.getCdpsDesc(this.manager.address, proxy.address).then(([cdpIds, urns, ilks]) =>
       cdpIds.map((cdpId, i) => ({
-        id: cdpId,
+        id: toFixedNumber(cdpId, INT_FORMAT),
         urn: urns[i]!,
         ilk: IlkType.fromBytes32(ilks[i]!),
         owner: proxy,

--- a/contracts/ProxyActionsHelper.ts
+++ b/contracts/ProxyActionsHelper.ts
@@ -1,12 +1,12 @@
 import { DssProxyActions__factory } from 'generated/types';
 
-import { toBigNumber, UnitFormats } from './math';
+import { INT_FORMAT, toBigNumber, UnitFormats } from './math';
 
 import type CDPManagerHelper from './CDPManagerHelper';
 import type EthereumProvider from './EthereumProvider';
 import type { IlkInfo } from './IlkRegistryHelper';
 import type JugHelper from './JugHelper';
-import type { FixedNumber, BigNumber, PayableOverrides } from 'ethers';
+import type { FixedNumber, PayableOverrides } from 'ethers';
 import type { DssProxyActions, DSProxy, DaiJoin } from 'generated/types';
 
 export default class ProxyActionsHelper {
@@ -35,7 +35,7 @@ export default class ProxyActionsHelper {
     jug: JugHelper,
     daiJoin: DaiJoin,
     ilkInfo: IlkInfo,
-    cdpId: BigNumber,
+    cdpId: FixedNumber,
     collateralAmount: FixedNumber,
     daiAmount: FixedNumber,
   ) {
@@ -46,7 +46,7 @@ export default class ProxyActionsHelper {
           jug.address,
           ilkInfo.gemJoin.address,
           daiJoin.address,
-          cdpId,
+          toBigNumber(cdpId, INT_FORMAT),
           toBigNumber(daiAmount, UnitFormats.WAD),
         ]),
         {
@@ -64,7 +64,7 @@ export default class ProxyActionsHelper {
         jug.address,
         ilkInfo.gemJoin.address,
         daiJoin.address,
-        cdpId,
+        toBigNumber(cdpId, INT_FORMAT),
         toBigNumber(collateralAmount, ilkInfo.gem.format),
         toBigNumber(daiAmount, UnitFormats.WAD),
         /* transferFrom */ true,
@@ -117,7 +117,7 @@ export default class ProxyActionsHelper {
     cdpManager: CDPManagerHelper,
     daiJoin: DaiJoin,
     ilkInfo: IlkInfo,
-    cdpId: BigNumber,
+    cdpId: FixedNumber,
     collateralAmount: FixedNumber,
     daiAmount: FixedNumber,
   ) {
@@ -127,7 +127,7 @@ export default class ProxyActionsHelper {
           cdpManager.address,
           ilkInfo.gemJoin.address,
           daiJoin.address,
-          cdpId,
+          toBigNumber(cdpId, INT_FORMAT),
           toBigNumber(collateralAmount, ilkInfo.gem.format),
           toBigNumber(daiAmount, UnitFormats.WAD),
         ]),
@@ -139,7 +139,7 @@ export default class ProxyActionsHelper {
         cdpManager.address,
         ilkInfo.gemJoin.address,
         daiJoin.address,
-        cdpId,
+        toBigNumber(cdpId, INT_FORMAT),
         toBigNumber(collateralAmount, ilkInfo.gem.format),
         toBigNumber(daiAmount, UnitFormats.WAD),
       ]),

--- a/contracts/Vault.ts
+++ b/contracts/Vault.ts
@@ -5,7 +5,7 @@ import { assertFixedFormat, getBiggestDecimalsFormat, UnitFormats } from './math
 import type ChainLogHelper from './ChainLogHelper';
 import type { IlkInfo } from './IlkRegistryHelper';
 import type { IlkStatus } from './VatHelper';
-import type { FixedNumber, BigNumber } from 'ethers';
+import type { FixedNumber } from 'ethers';
 // eslint-disable-next-line unused-imports/no-unused-imports
 import type PromiseConstructor from 'types/promise';
 
@@ -27,9 +27,9 @@ const getDaiAmount = (colAmount: FixedNumber, debtMultiplier: FixedNumber, liqRa
 
 export default class Vault {
   readonly ilkInfo: IlkInfo;
-  private readonly cdpId: BigNumber;
+  private readonly cdpId: FixedNumber;
 
-  constructor(ilkInfo: IlkInfo, cdpId: BigNumber) {
+  constructor(ilkInfo: IlkInfo, cdpId: FixedNumber) {
     this.ilkInfo = ilkInfo;
     this.cdpId = cdpId;
   }

--- a/contracts/math.ts
+++ b/contracts/math.ts
@@ -4,6 +4,8 @@ import { FixedNumber } from 'ethers';
 
 import type { BigNumber } from 'ethers';
 
+export const INT_FORMAT = FixedFormat.from(0);
+
 /* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Number formats of Maker Protocol

--- a/pages/forms/stringNumber.ts
+++ b/pages/forms/stringNumber.ts
@@ -31,9 +31,9 @@ export const cutDecimals = (input: string, dec: number) => {
   return input;
 };
 
-export const toFixedNumberOrUndefined = (input: string, format: FixedFormat) => {
+export const toFixedNumberOrUndefined = (input: string | undefined, format: FixedFormat) => {
   try {
-    return FixedNumber.fromString(input, format);
+    return input === undefined ? undefined : FixedNumber.fromString(input, format);
   } catch {
     return undefined;
   }

--- a/pages/vaults/[id]/index.page.tsx
+++ b/pages/vaults/[id]/index.page.tsx
@@ -12,6 +12,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
+import { FixedNumber } from 'ethers';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
@@ -33,14 +34,13 @@ import type CDPManagerHelper from 'contracts/CDPManagerHelper';
 import type ChainLogHelper from 'contracts/ChainLogHelper';
 import type { CDP } from 'contracts/GetCDPsHelper';
 import type { IlkStatus } from 'contracts/VatHelper';
-import type { FixedNumber } from 'ethers';
 import type { NextPageWithEthereum } from 'next';
 import type { BurnFormProps } from 'pages/forms/BurnForm';
 import type { MintFormProps } from 'pages/forms/MintForm';
 import type { FC } from 'react';
 
-const useCDP = (cdpManager: CDPManagerHelper | undefined, cdpId: FixedNumber | undefined) =>
-  usePromiseFactory(useCallback(async () => cdpId && cdpManager?.getCDP(cdpId), [cdpManager, cdpId]))[0];
+const useCDP = (cdpManager: CDPManagerHelper | undefined, cdpId: FixedNumber) =>
+  usePromiseFactory(useCallback(async () => cdpManager?.getCDP(cdpId), [cdpManager, cdpId]))[0];
 
 const useProxyAddress = (chainLog: ChainLogHelper) => {
   const proxyRegistry = useProxyRegistry(chainLog);
@@ -195,7 +195,10 @@ const Content: FC<ContentProps> = ({ chainLog, cdp, address }) => {
 
 const VaultDetail: NextPageWithEthereum = ({ provider }) => {
   const router = useRouter();
-  const cdpId = useMemo(() => toFixedNumberOrUndefined(getStringQuery(router.query.id), INT_FORMAT), [router.query.id]);
+  const cdpId = useMemo(
+    () => toFixedNumberOrUndefined(getStringQuery(router.query.id), INT_FORMAT) || FixedNumber.fromString('0', INT_FORMAT),
+    [router.query.id],
+  );
   const chainLog = useChainLog(provider);
   const cdpManager = useCDPManager(chainLog);
   const cdp = useCDP(cdpManager, cdpId);

--- a/pages/vaults/[id]/index.page.tsx
+++ b/pages/vaults/[id]/index.page.tsx
@@ -12,15 +12,16 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
-import { BigNumber } from 'ethers';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 
 import Vault from 'contracts/Vault';
+import { INT_FORMAT } from 'contracts/math';
 import { useCDPManager, useChainLog, useProxyRegistry } from 'pages/ethereum/ContractHooks';
 import BurnForm from 'pages/forms/BurnForm';
 import MintForm from 'pages/forms/MintForm';
+import { toFixedNumberOrUndefined } from 'pages/forms/stringNumber';
 import IlkStatusCard, { useIlkStatusCardProps } from 'pages/ilks/[ilk]/IlkStatusCard';
 import { getStringQuery } from 'pages/query';
 import usePromiseFactory from 'pages/usePromiseFactory';
@@ -38,8 +39,8 @@ import type { BurnFormProps } from 'pages/forms/BurnForm';
 import type { MintFormProps } from 'pages/forms/MintForm';
 import type { FC } from 'react';
 
-const useCDP = (cdpManager: CDPManagerHelper | undefined, cdpId: BigNumber) =>
-  usePromiseFactory(useCallback(async () => cdpManager?.getCDP(cdpId), [cdpManager, cdpId]))[0];
+const useCDP = (cdpManager: CDPManagerHelper | undefined, cdpId: FixedNumber | undefined) =>
+  usePromiseFactory(useCallback(async () => cdpId && cdpManager?.getCDP(cdpId), [cdpManager, cdpId]))[0];
 
 const useProxyAddress = (chainLog: ChainLogHelper) => {
   const proxyRegistry = useProxyRegistry(chainLog);
@@ -194,7 +195,7 @@ const Content: FC<ContentProps> = ({ chainLog, cdp, address }) => {
 
 const VaultDetail: NextPageWithEthereum = ({ provider }) => {
   const router = useRouter();
-  const cdpId = useMemo(() => BigNumber.from(getStringQuery(router.query.id)), [router.query.id]);
+  const cdpId = useMemo(() => toFixedNumberOrUndefined(getStringQuery(router.query.id), INT_FORMAT), [router.query.id]);
   const chainLog = useChainLog(provider);
   const cdpManager = useCDPManager(chainLog);
   const cdp = useCDP(cdpManager, cdpId);
@@ -214,7 +215,7 @@ const VaultDetail: NextPageWithEthereum = ({ provider }) => {
 
   return (
     <Card elevation={0}>
-      <CardHeader title={`${cdp.ilk.inString} Vault (${cdpId.toString()})`} subheader={cdp.urn} />
+      <CardHeader title={`${cdp.ilk.inString} Vault (${cdpId?.toString()})`} subheader={cdp.urn} />
       <CardContent>
         <Content chainLog={chainLog} cdp={cdp} address={provider.address} />
       </CardContent>

--- a/pages/vaults/index.page.tsx
+++ b/pages/vaults/index.page.tsx
@@ -62,7 +62,7 @@ const Content: FC<ContentProps> = ({ cdps }) => {
     <List>
       {cdps.map(({ id, urn, ilk }) => (
         <ListItem key={id.toString()} disablePadding>
-          <Link href={`/vaults/${id.toHexString()}`} passHref>
+          <Link href={`/vaults/${id.toString()}`} passHref>
             <ListItemButton>
               <ListItemIcon>
                 <AccountBalanceWalletIcon />


### PR DESCRIPTION
`router.query.id` が `undefined` の場合に無限ロード状態になる問題が見つかったので、合わせて `BigNumber` を使用しないように修正しました。変更の過程でhexを利用するほうが面倒になったのでURL上のIDをdecimalにしています。
